### PR TITLE
[RF] Avoid mutable in defaults 

### DIFF
--- a/nilearn/input_data/fmriprep_confounds.py
+++ b/nilearn/input_data/fmriprep_confounds.py
@@ -3,6 +3,7 @@
 Authors: Pierre Bellec, François Paugam, Hanad Sharmarke, Hao-Ting Wang,
 Michael W. Weiss, Steven Meisler, Thibault Piront.
 """
+import warnings
 import pandas as pd
 from .fmriprep_confounds_utils import (_sanitize_confounds, _confounds_to_df,
                                        _prepare_output, MissingConfound)
@@ -14,38 +15,42 @@ all_confounds = [
     "motion",
     "high_pass",
     "wm_csf",
-    "global",
+    "global_signal",
     "compcor",
     "ica_aroma",
     "scrub",
-    "non_steady_state",
+    "non_steady_state"
 ]
 
 # extra parameters needed for each noise component
 component_parameters = {
     "motion": ["motion"],
     "wm_csf": ["wm_csf"],
-    "global": ["global_signal"],
+    "global_signal": ["global_signal"],
     "compcor": ["meta_json", "compcor", "n_compcor"],
     "ica_aroma": ["ica_aroma"],
     "scrub": ["scrub", "fd_thresh", "std_dvars_thresh"],
 }
 
 
-def _sanitize_strategy(strategy):
-    """Define the supported denoising strategies."""
-    if not isinstance(strategy, list):
-        raise ValueError("strategy needs to be a list of strings")
+def _check_strategy(strategy):
+    """Ensure the denoising strategies are valid."""
+    if not isinstance(strategy, tuple):
+        raise ValueError("strategy needs to be a tuple of strings"
+                         f"{type(strategy)}")
     for conf in strategy:
+        if conf == "non_steady_state":
+            warnings.warn("Non-steady state volumes are always detected. It "
+                          "doesn't need to be supplied as part of the "
+                          "strategy. Supplying non_steady_state in strategy "
+                          "will not have additional effect.")
         if conf not in all_confounds:
             raise ValueError(f"{conf} is not a supported type of confounds.")
-    # add non steady state if not present
-    if "non_steady_state" not in strategy:
-        strategy.append("non_steady_state")
+
     # high pass filtering must be present if using fmriprep compcor outputs
-    if "compcor" in strategy and "high_pass" not in strategy:
-        strategy.append("high_pass")
-    return strategy
+    if ("compcor" in strategy) and ("high_pass" not in strategy):
+        raise ValueError("When using compcor, `high_pass` must be included in "
+                         f"strategy. Current strategy: '{strategy}'")
 
 
 def _check_error(missing):
@@ -61,7 +66,7 @@ def _check_error(missing):
 
 
 def fmriprep_confounds(img_files,
-                       strategy=["motion", "high_pass", "wm_csf"],
+                       strategy=("motion", "high_pass", "wm_csf"),
                        motion="full",
                        scrub=5, fd_thresh=0.2, std_dvars_thresh=3,
                        wm_csf="basic",
@@ -98,19 +103,37 @@ def fmriprep_confounds(img_files,
         - `func.gii`: list of a pair of paths to files, optionally as a list
           of lists.
 
-    strategy : list of strings, default ["motion", "high_pass", "wm_csf"]
+    strategy : tuple of strings, default ("motion", "high_pass", "wm_csf")
         The type of noise components to include.
 
-        - "motion":  head motion estimates.
-        - "high_pass" discrete cosines covering low frequencies.
+        - "motion":  head motion estimates. Associated parameter: `motion`
         - "wm_csf" confounds derived from white matter and cerebrospinal fluid.
-        - "global" confounds derived from the global signal.
+          Associated parameter: `wm_csf`
+        - "global_signal" confounds derived from the global signal.
+          Associated parameter: `global_signal`
         - "compcor" confounds derived from CompCor :footcite:`BEHZADI200790`.
+          When using this noise component, "high_pass" must also be applied.
+          Associated parameter: `compcor`, `n_compcor`
         - "ica_aroma" confounds derived from ICA-AROMA :footcite:`Pruim2015`.
+          Associated parameter: `ica_aroma`
         - "scrub" regressors for :footcite:`Power2014` scrubbing approach.
+          Associated parameter: `scrub`, `fd_threshold`, `std_dvars_threshold`
 
-        For each supplied strategy, associated parameters will be applied.
-        Otherwise, any values supplied to the parameters are ignored.
+        For each component above, associated parameters will be applied if
+        present. Otherwise, any values supplied to the parameters are ignored.
+        For example, if `strategy=('motion', 'global_signal')` will allow user
+        to supply input to associated parameter `motion` and `global_signal`;
+        if user pass `wm_csf` parameter, it will not be applied as it's not
+        part of the `strategy`.
+
+        There are two additional noise components with no optional parameters.
+
+        - "non_steady_state" denotes volumes collected before the fMRI scanner
+          has reached a stable state.
+        - "high_pass" discrete cosines covering low frequencies.
+
+        Non-steady-state volume will always be checked. There's no need to
+        supply this componenet to the strategy.
 
     motion : {'basic', 'power2', 'derivatives', 'full'}
         Type of confounds extracted from head motion estimates.
@@ -120,16 +143,6 @@ def fmriprep_confounds(img_files,
         - "derivatives" translation/rotation + derivatives (12 parameters)
         - "full" translation/rotation + derivatives + quadratic terms + power2d
           derivatives (24 parameters)
-
-    fd_threshold : float, default 0.2
-        Framewise displacement threshold for scrub (default = 0.2 mm)
-
-    std_dvars_threshold : float, default 3
-        Standardized DVARS threshold for scrub (default = 3).
-        DVARs is defined as root mean squared intensity difference of volume N
-        to volume N+1 :footcite:`Power2012`. D referring to temporal derivative
-        of timecourses, VARS referring to root mean squared variance over
-        voxels.
 
     wm_csf : {'basic', 'power2', 'derivatives', 'full'}
         Type of confounds extracted from masks of white matter and
@@ -157,6 +170,16 @@ def fmriprep_confounds(img_files,
         is 0, temove time frames based on excessive framewise displacement and
         DVARS only. One-hot encoding vectors are added as regressors for each
         scrubbed frame.
+
+    fd_threshold : float, default 0.2
+        Framewise displacement threshold for scrub (default = 0.2 mm)
+
+    std_dvars_threshold : float, default 3
+        Standardized DVARS threshold for scrub (default = 3).
+        DVARs is defined as root mean squared intensity difference of volume N
+        to volume N+1 :footcite:`Power2012`. D referring to temporal derivative
+        of timecourses, VARS referring to root mean squared variance over
+        voxels.
 
     compcor : {'anat_combined', 'anat_separated', 'temporal',\
     'temporal_anat_combined', 'temporal_anat_separated'}
@@ -235,25 +258,23 @@ def fmriprep_confounds(img_files,
     .. footbibliography::
 
     """
-    strategy = _sanitize_strategy(strategy)
+    _check_strategy(strategy)
 
     # load confounds per image provided
     img_files, flag_single = _sanitize_confounds(img_files)
     confounds_out = []
     sample_mask_out = []
     for file in img_files:
-        sample_mask, conf = _load_single(file,
-                                         strategy,
-                                         demean,
-                                         motion=motion,
-                                         scrub=scrub,
-                                         fd_thresh=fd_thresh,
-                                         std_dvars_thresh=std_dvars_thresh,
-                                         wm_csf=wm_csf,
-                                         global_signal=global_signal,
-                                         compcor=compcor,
-                                         n_compcor=n_compcor,
-                                         ica_aroma=ica_aroma)
+        sample_mask, conf = _load_single(
+            file, strategy, demean,
+            motion=motion,
+            scrub=scrub,
+            fd_threshold=fd_thresh,
+            std_dvars_threshold=std_dvars_thresh,
+            wm_csf=wm_csf,
+            global_signal=global_signal,
+            compcor=compcor, n_compcor=n_compcor,
+            ica_aroma=ica_aroma)
         confounds_out.append(conf)
         sample_mask_out.append(sample_mask)
 
@@ -279,11 +300,16 @@ def _load_single(confounds_raw, strategy, demean, **kargs):
         confounds_raw, flag_acompcor, flag_full_aroma
     )
 
-    confounds = pd.DataFrame()
     missing = {"confounds": [], "keywords": []}
+    # always check non steady state volumes are loaded
+    confounds, missing = _load_noise_component(confounds_raw,
+                                               "non_steady_state",
+                                               missing, meta_json=meta_json,
+                                               **kargs)
     for component in strategy:
         loaded_confounds, missing = _load_noise_component(
-            confounds_raw, component, missing, meta_json=meta_json, **kargs)
+            confounds_raw, component, missing, meta_json=meta_json,
+            **kargs)
         confounds = pd.concat([confounds, loaded_confounds], axis=1)
 
     _check_error(missing)  # raise any missing

--- a/nilearn/input_data/fmriprep_confounds.py
+++ b/nilearn/input_data/fmriprep_confounds.py
@@ -265,16 +265,18 @@ def fmriprep_confounds(img_files,
     confounds_out = []
     sample_mask_out = []
     for file in img_files:
-        sample_mask, conf = _load_single(
-            file, strategy, demean,
-            motion=motion,
-            scrub=scrub,
-            fd_threshold=fd_thresh,
-            std_dvars_threshold=std_dvars_thresh,
-            wm_csf=wm_csf,
-            global_signal=global_signal,
-            compcor=compcor, n_compcor=n_compcor,
-            ica_aroma=ica_aroma)
+        sample_mask, conf = _load_single(file,
+                                         strategy,
+                                         demean,
+                                         motion=motion,
+                                         scrub=scrub,
+                                         fd_thresh=fd_thresh,
+                                         std_dvars_thresh=std_dvars_thresh,
+                                         wm_csf=wm_csf,
+                                         global_signal=global_signal,
+                                         compcor=compcor,
+                                         n_compcor=n_compcor,
+                                         ica_aroma=ica_aroma)
         confounds_out.append(conf)
         sample_mask_out.append(sample_mask)
 

--- a/nilearn/input_data/fmriprep_confounds.py
+++ b/nilearn/input_data/fmriprep_confounds.py
@@ -35,8 +35,8 @@ component_parameters = {
 
 def _check_strategy(strategy):
     """Ensure the denoising strategies are valid."""
-    if not isinstance(strategy, tuple):
-        raise ValueError("strategy needs to be a tuple of strings"
+    if (not isinstance(strategy, tuple)) and (not isinstance(strategy, list)):
+        raise ValueError("strategy needs to be a tuple or list of strings"
                          f"{type(strategy)}")
     for conf in strategy:
         if conf == "non_steady_state":
@@ -103,7 +103,8 @@ def fmriprep_confounds(img_files,
         - `func.gii`: list of a pair of paths to files, optionally as a list
           of lists.
 
-    strategy : tuple of strings, default ("motion", "high_pass", "wm_csf")
+    strategy : tuple or list of strings.
+        Default ("motion", "high_pass", "wm_csf")
         The type of noise components to include.
 
         - "motion":  head motion estimates. Associated parameter: `motion`

--- a/nilearn/input_data/fmriprep_confounds_components.py
+++ b/nilearn/input_data/fmriprep_confounds_components.py
@@ -32,7 +32,7 @@ def _load_wm_csf(confounds_raw, wm_csf):
     return confounds_raw[wm_csf_params]
 
 
-def _load_global(confounds_raw, global_signal):
+def _load_global_signal(confounds_raw, global_signal):
     """Load the regressors derived from the global signal."""
     global_params = _add_suffix(["global_signal"], global_signal)
     _check_params(confounds_raw, global_params)

--- a/nilearn/input_data/fmriprep_confounds_strategy.py
+++ b/nilearn/input_data/fmriprep_confounds_strategy.py
@@ -28,8 +28,8 @@ preset_strategies = {
         "motion": "full",
         "wm_csf": "full",
         "scrub": 5,
-        "fd_threshold": 0.2,
-        "std_dvars_threshold": 3,
+        "fd_thresh": 0.2,
+        "std_dvars_thresh": 3,
         "global_signal": None,
         "demean": True
     },

--- a/nilearn/input_data/fmriprep_confounds_strategy.py
+++ b/nilearn/input_data/fmriprep_confounds_strategy.py
@@ -16,7 +16,7 @@ from . import fmriprep_confounds
 preset_strategies = {
     "simple": {
         "strategy":
-            ["high_pass", "non_steady_state", "motion", "wm_csf"],
+            ("high_pass", "motion", "wm_csf"),
         "motion": "full",
         "wm_csf": "basic",
         "global_signal": None,
@@ -24,18 +24,18 @@ preset_strategies = {
     },
     "scrubbing": {
         "strategy":
-            ["high_pass", "non_steady_state", "motion", "wm_csf", "scrub"],
+            ("high_pass", "motion", "wm_csf", "scrub"),
         "motion": "full",
         "wm_csf": "full",
         "scrub": 5,
-        "fd_thresh": 0.2,
-        "std_dvars_thresh": 3,
+        "fd_threshold": 0.2,
+        "std_dvars_threshold": 3,
         "global_signal": None,
         "demean": True
     },
     "compcor": {
         "strategy":
-            ["high_pass", "non_steady_state", "motion", "compcor"],
+            ("high_pass", "motion", "compcor"),
         "motion": "full",
         "n_compcor": "all",
         "compcor": "anat_combined",
@@ -43,7 +43,7 @@ preset_strategies = {
     },
     "ica_aroma": {
         "strategy":
-            ["high_pass", "non_steady_state", "wm_csf", "ica_aroma"],
+            ("high_pass", "wm_csf", "ica_aroma"),
         "wm_csf": "basic",
         "ica_aroma": "full",
         "global_signal": None,
@@ -237,7 +237,7 @@ def _update_user_inputs(kwargs, default_parameters, check_parameters):
         # recognisable value to the global_signal parameter
         if key == "global_signal":
             if isinstance(value, str):
-                parameters["strategy"].append("global")
+                parameters["strategy"] += ("global_signal", )
             else:  # remove global signal if not updated
                 parameters.pop("global_signal", None)
     # collect remaining parameters in kwargs that are not needed

--- a/nilearn/input_data/tests/test_fmriprep_confounds.py
+++ b/nilearn/input_data/tests/test_fmriprep_confounds.py
@@ -493,7 +493,7 @@ def test_sample_mask(tmp_path):
     )
 
     reg, mask = fmriprep_confounds(
-        regular_nii, strategy=("motion", "scrub"), scrub=5, fd_threshold=0.15
+        regular_nii, strategy=("motion", "scrub"), scrub=5, fd_thresh=0.15
     )
     # the current test data has 6 time points marked as motion outliers,
     # and one nonsteady state (overlap with the first motion outlier)
@@ -515,7 +515,7 @@ def test_sample_mask(tmp_path):
 
     # When no volumes needs removing (very liberal motion threshould)
     reg, mask = fmriprep_confounds(
-        regular_nii, strategy=("motion", "scrub"), scrub=0, fd_threshold=4
+        regular_nii, strategy=("motion", "scrub"), scrub=0, fd_thresh=4
     )
     assert mask is None
 

--- a/nilearn/input_data/tests/test_fmriprep_confounds.py
+++ b/nilearn/input_data/tests/test_fmriprep_confounds.py
@@ -8,7 +8,7 @@ import pytest
 from nibabel import Nifti1Image
 from nilearn.input_data import NiftiMasker
 from nilearn.input_data import fmriprep_confounds
-from ..fmriprep_confounds import _sanitize_strategy
+from ..fmriprep_confounds import _check_strategy
 
 from nilearn._utils.fmriprep_confounds import _to_camel_case
 
@@ -29,7 +29,7 @@ def _simu_img(tmp_path, demean):
     # demean set to False just for simulating signal based on the original
     # state
     confounds, _ = fmriprep_confounds(
-        file_nii, strategy=["motion"], motion="basic", demean=False
+        file_nii, strategy=("motion", ), motion="basic", demean=False
     )
 
     X = _handle_non_steady(confounds)
@@ -72,7 +72,7 @@ def _simu_img(tmp_path, demean):
 
     # generate the associated confounds for testing
     test_confounds, _ = fmriprep_confounds(
-        file_nii, strategy=["motion"], motion="basic", demean=demean)
+        file_nii, strategy=("motion",), motion="basic", demean=demean)
     # match how we extend the length to increase the degree of freedom
     test_confounds = _handle_non_steady(test_confounds)
     sample_mask = np.arange(test_confounds.shape[0])[1:]
@@ -110,24 +110,24 @@ def _regression(confounds, tmp_path):
 
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize(
-    "strategy,param",
+    "test_strategy,param",
     [
-        ("motion", {}),
-        ("high_pass", {}),
-        ("wm_csf", {"wm_csf": "full"}),
-        ("global", {"global_signal": "full"}),
-        ("compcor", {}),
-        ("compcor", {"compcor": "anat_separated"}),
-        ("compcor", {"compcor": "temporal"}),
-        ("ica_aroma", {"ica_aroma": "basic"}),
+        (("motion", ), {}),
+        (("high_pass", ), {}),
+        (("wm_csf", ), {"wm_csf": "full"}),
+        (("global_signal", ), {"global_signal": "full"}),
+        (("high_pass", "compcor", ), {}),
+        (("high_pass", "compcor", ), {"compcor": "anat_separated"}),
+        (("high_pass", "compcor", ), {"compcor": "temporal"}),
+        (("ica_aroma", ), {"ica_aroma": "basic"}),
     ],
 )
-def test_nilearn_regress(tmp_path, strategy, param):
+def test_nilearn_regress(tmp_path, test_strategy, param):
     """Try regressing out all motion types without sample mask."""
     img_nii, _ = create_tmp_filepath(
         tmp_path, copy_confounds=True, copy_json=True
     )
-    confounds, _ = fmriprep_confounds(img_nii, strategy=[strategy], **param)
+    confounds, _ = fmriprep_confounds(img_nii, strategy=test_strategy, **param)
     _regression(confounds, tmp_path)
 
 
@@ -240,17 +240,13 @@ def test_confounds2df(tmp_path):
     assert "trans_x" in confounds.columns
 
 
-@pytest.mark.parametrize("strategy", [["string"], "error", [0], "motion"])
-def test_sanitize_strategy(tmp_path, strategy):
+@pytest.mark.parametrize("strategy",
+                         [("string", ), "error", (0, ), ("compcor", )])
+def test_check_strategy(strategy):
     """Check that flawed strategy options generate meaningful error
     messages."""
-    img_nii, _ = create_tmp_filepath(tmp_path, copy_confounds=True)
-    if strategy == "motion":
-        checked_strategy = _sanitize_strategy(strategy=[strategy])
-        assert "non_steady_state" in checked_strategy
-    else:
-        with pytest.raises(ValueError):
-            _sanitize_strategy(strategy=strategy)
+    with pytest.raises(ValueError):
+        _check_strategy(strategy=strategy)
 
 
 SUFFIXES = np.array(["", "_derivative1", "_power2", "_derivative1_power2"])
@@ -274,7 +270,7 @@ def expected_suffixes(motion):
 def test_motion(tmp_path, motion, param, expected_suffixes):
     img_nii, _ = create_tmp_filepath(tmp_path, copy_confounds=True)
     conf, _ = fmriprep_confounds(
-        img_nii, strategy=["motion"], motion=motion
+        img_nii, strategy=("motion", ), motion=motion
     )
     for suff in SUFFIXES:
         if suff in expected_suffixes:
@@ -292,7 +288,8 @@ def test_n_compcor(tmp_path, compcor, n_compcor, test_keyword, test_n):
         tmp_path, copy_confounds=True, copy_json=True
     )
     conf, _ = fmriprep_confounds(
-        img_nii, strategy=["compcor"], compcor=compcor, n_compcor=n_compcor
+        img_nii, strategy=("high_pass", "compcor", ), compcor=compcor,
+        n_compcor=n_compcor
     )
     assert sum(True for col in conf.columns if test_keyword in col) == test_n
 
@@ -325,7 +322,7 @@ def test_not_found_exception(tmp_path):
     with pytest.raises(ValueError) as exc_info:
         fmriprep_confounds(
             img_missing_confounds,
-            strategy=["high_pass", "motion", "global"],
+            strategy=("high_pass", "motion", "global_signal", ),
             global_signal="full",
             motion="full",
         )
@@ -337,14 +334,15 @@ def test_not_found_exception(tmp_path):
     with pytest.raises(ValueError):
         fmriprep_confounds(
             img_missing_confounds,
-            strategy=["compcor"],
+            strategy=("high_pass", "compcor"),
             compcor="anat_combined",
         )
 
     # catch invalid compcor option
     with pytest.raises(KeyError):
         fmriprep_confounds(
-            img_missing_confounds, strategy=["compcor"], compcor="blah"
+            img_missing_confounds, strategy=("high_pass", "compcor"),
+            compcor="blah"
         )
 
     # Aggressive ICA-AROMA strategy requires
@@ -352,7 +350,7 @@ def test_not_found_exception(tmp_path):
     # correct nifti but missing noise regressor
     with pytest.raises(ValueError) as exc_info:
         fmriprep_confounds(
-            img_missing_confounds, strategy=["ica_aroma"], ica_aroma="basic"
+            img_missing_confounds, strategy=("ica_aroma", ), ica_aroma="basic"
         )
     assert "aroma" in exc_info.value.args[0]
 
@@ -363,7 +361,7 @@ def test_not_found_exception(tmp_path):
     )
     with pytest.raises(ValueError) as exc_info:
         fmriprep_confounds(
-            aroma_nii, strategy=["ica_aroma"], ica_aroma="basic"
+            aroma_nii, strategy=("ica_aroma", ), ica_aroma="basic"
         )
     assert "Invalid file type" in exc_info.value.args[0]
 
@@ -371,7 +369,7 @@ def test_not_found_exception(tmp_path):
     # desc-smoothAROMAnonaggr nifti file
     with pytest.raises(ValueError) as exc_info:
         fmriprep_confounds(
-            img_missing_confounds, strategy=["ica_aroma"], ica_aroma="full"
+            img_missing_confounds, strategy=("ica_aroma", ), ica_aroma="full"
         )
     assert "desc-smoothAROMAnonaggr_bold" in exc_info.value.args[0]
 
@@ -380,6 +378,18 @@ def test_not_found_exception(tmp_path):
     with pytest.raises(ValueError) as exc_info:
         fmriprep_confounds(img_missing_confounds)
     assert "Could not find associated confound file." in exc_info.value.args[0]
+
+
+def test_non_steady_state(tmp_path):
+    """Warn when 'non_steady_state' is in strategy."""
+    # supplying 'non_steady_state' in strategy is not necessary
+    # check warning is correcly raised
+    img, conf = create_tmp_filepath(
+        tmp_path, copy_confounds=True
+    )
+    warning_message = (r"Non-steady state")
+    with pytest.warns(UserWarning, match=warning_message):
+        fmriprep_confounds(img, strategy=('non_steady_state', 'motion'))
 
 
 def test_load_non_nifti(tmp_path):
@@ -456,7 +466,7 @@ def test_ica_aroma(tmp_path):
     )
     # Aggressive strategy
     conf, _ = fmriprep_confounds(
-        regular_nii, strategy=["ica_aroma"], ica_aroma="basic"
+        regular_nii, strategy=("ica_aroma", ), ica_aroma="basic"
     )
     for col_name in conf.columns:
         # only aroma and non-steady state columns will be present
@@ -464,14 +474,14 @@ def test_ica_aroma(tmp_path):
 
     # Non-aggressive strategy
     conf, _ = fmriprep_confounds(
-        aroma_nii, strategy=["ica_aroma"], ica_aroma="full"
+        aroma_nii, strategy=("ica_aroma", ), ica_aroma="full"
     )
     assert conf.size == 0
 
     # invalid combination of strategy and option
     with pytest.raises(ValueError) as exc_info:
         conf, _ = fmriprep_confounds(
-            regular_nii, strategy=["ica_aroma"], ica_aroma="invalid"
+            regular_nii, strategy=("ica_aroma", ), ica_aroma="invalid"
         )
     assert "Current input: invalid" in exc_info.value.args[0]
 
@@ -483,7 +493,7 @@ def test_sample_mask(tmp_path):
     )
 
     reg, mask = fmriprep_confounds(
-        regular_nii, strategy=["motion", "scrub"], scrub=5, fd_thresh=0.15
+        regular_nii, strategy=("motion", "scrub"), scrub=5, fd_threshold=0.15
     )
     # the current test data has 6 time points marked as motion outliers,
     # and one nonsteady state (overlap with the first motion outlier)
@@ -494,18 +504,18 @@ def test_sample_mask(tmp_path):
     assert reg.shape[0] == 30
 
     # non steady state will always be removed
-    reg, mask = fmriprep_confounds(regular_nii, strategy=["motion"])
+    reg, mask = fmriprep_confounds(regular_nii, strategy=("motion", ))
     assert reg.shape[0] - len(mask) == 1
 
     # When no non-steady state volumes are present
     conf_data, _ = get_leagal_confound(non_steady_state=False)
     conf_data.to_csv(regular_conf, sep="\t", index=False)  # save to tmp
-    reg, mask = fmriprep_confounds(regular_nii, strategy=["motion"])
+    reg, mask = fmriprep_confounds(regular_nii, strategy=("motion", ))
     assert mask is None
 
     # When no volumes needs removing (very liberal motion threshould)
     reg, mask = fmriprep_confounds(
-        regular_nii, strategy=["motion", "scrub"], scrub=0, fd_thresh=4
+        regular_nii, strategy=("motion", "scrub"), scrub=0, fd_threshold=4
     )
     assert mask is None
 
@@ -528,7 +538,7 @@ def test_inputs(tmp_path, image_type):
         files.append(nii)
 
     if image_type == "ica_aroma":
-        conf, _ = fmriprep_confounds(files, strategy=["ica_aroma"])
+        conf, _ = fmriprep_confounds(files, strategy=("ica_aroma", ))
     else:
         conf, _ = fmriprep_confounds(files)
     assert len(conf) == 2

--- a/nilearn/input_data/tests/test_fmriprep_confounds.py
+++ b/nilearn/input_data/tests/test_fmriprep_confounds.py
@@ -240,13 +240,17 @@ def test_confounds2df(tmp_path):
     assert "trans_x" in confounds.columns
 
 
-@pytest.mark.parametrize("strategy",
-                         [("string", ), "error", (0, ), ("compcor", )])
-def test_check_strategy(strategy):
+@pytest.mark.parametrize("strategy,message",
+                         [(["string", ], "not a supported type of confounds."),
+                          ("error", "tuple or list of strings"),
+                          ((0, ), "not a supported type of confounds."),
+                          (("compcor", ), "high_pass")])
+def test_check_strategy(strategy, message):
     """Check that flawed strategy options generate meaningful error
     messages."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         _check_strategy(strategy=strategy)
+    assert message in exc_info.value.args[0]
 
 
 SUFFIXES = np.array(["", "_derivative1", "_power2", "_derivative1_power2"])

--- a/nilearn/plotting/surf_plotting.py
+++ b/nilearn/plotting/surf_plotting.py
@@ -375,7 +375,6 @@ def _compute_facecolors_matplotlib(bg_map, faces, n_vertices,
     # set alpha if in auto mode
     if alpha == 'auto':
         alpha = .5 if bg_map is None else 1
-    face_colors = np.ones((faces.shape[0], 4))
     if bg_map is None:
         bg_data = np.ones(n_vertices) * 0.5
     else:


### PR DESCRIPTION
Resolve issue raised in PR https://github.com/nilearn/nilearn/pull/3047
- change to argument `strategy`: accept tuple instead of list
- modify all tests associated with this change
- document the behaviour of `'non_steady_state'` and `'compcor'`
- raise warning when `'compcor'` is not accompanied with `'high_pass'`

Unrelated refactoring:
- change the name of option 'global' in strategy to 'global_signal'
  Explicit name and avoid confusion with python keyword global